### PR TITLE
Add support for IEEE 1588 MAC multicast address

### DIFF
--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -50,7 +50,8 @@
 #include <list>
 
 #define ONE_WAY_PHY_DELAY 400	/*!< One way phy delay. TX or RX phy delay default value*/
-#define P8021AS_MULTICAST "\x01\x80\xC2\x00\x00\x0E"	/*!< Default multicast address*/
+#define P8021AS_MULTICAST "\x01\x80\xC2\x00\x00\x0E"	/*!< Default IEEE 802.1AS multicast address*/
+#define IEEE_1588_MULTICAST "\x01\x1B\x19\x00\x00\x00"	/*!< Default IEEE 1588-2008 multicast address*/
 #define PTP_DEVICE "/dev/ptpXX"			/*!< Default PTP device */
 #define PTP_DEVICE_IDX_OFFS 8			/*!< PTP device index offset*/
 #define CLOCKFD 3						/*!< Clock file descriptor */


### PR DESCRIPTION
Although IEEE 802.1AS defines only 01:80:C2:00:00:0E as the default
multicast MAC address for PTP messages, IEEE 1588-2008 defines also
01:1B:19:00:00:00 as the multicast MAC address for all but peer delay
(Pdelay_Req, Pdelay_Resp, Pdelay_Resp_Follow_Up) messages.

This is why this commit adds also support for 01:1B:19:00:00:00 multicast
MAC address for incoming PTP messages.