### PR TITLE
gptp: ignore syncFollowUp with negative correction field

### DIFF
--- a/common/common_port.cpp
+++ b/common/common_port.cpp
@@ -71,6 +71,7 @@ CommonPort::CommonPort( PortInit_t *portInit ) :
 	pdelay_count = 0;
 	asCapable = false;
 	link_speed = INVALID_LINKSPEED;
+	allow_negative_correction_field = portInit->allowNegativeCorrField;
 }
 
 CommonPort::~CommonPort()

--- a/common/common_port.hpp
+++ b/common/common_port.hpp
@@ -268,6 +268,10 @@ typedef struct {
 
 	/* neighbor delay threshold */
 	int64_t neighborPropDelayThreshold;
+
+	/* Allow processing SyncFollowUp with
+	 * negative correction field */
+	bool allowNegativeCorrField;
 } PortInit_t;
 
 
@@ -321,6 +325,7 @@ private:
 	PortState port_state;
 	bool testMode;
 	bool automotive_profile;
+	bool allow_negative_correction_field;
 
 	signed char log_mean_sync_interval;
 	signed char log_mean_announce_interval;
@@ -1455,6 +1460,16 @@ public:
 	 * @brief Returns RX PHY delay
 	 */
 	Timestamp getRxPhyDelay( uint32_t link_speed ) const;
+
+	/**
+	* @brief Gets the permission flag for processing SyncFollowUp
+	* messages with negative correction field
+	* @return allow_negative_correction_field flag
+	*/
+	bool getAllowNegativeCorrField( void )
+	{
+		return( allow_negative_correction_field );
+	}
 };
 
 /**

--- a/common/gptp_cfg.cpp
+++ b/common/gptp_cfg.cpp
@@ -148,6 +148,16 @@ int GptpIniParser::iniCallBack(void *user, const char *section, const char *name
                 parser->_config.lostPdelayRespThresh = lostpdelayth;
             }
         }
+        else if( parseMatch( name, "allowNegativeCorrectionField") )
+        {
+            errno = 0;
+            char *pEnd;
+            unsigned int allowNegCF = strtoul(value, &pEnd, 10);
+            if( *pEnd == '\0' && errno == 0 && (allowNegCF == 0 || allowNegCF == 1) ) {
+                valOK = true;
+                parser->_config.allowNegativeCorrField = (allowNegCF == 1);
+            }
+        }
     }
     else if( parseMatch(section, "eth") )
     {

--- a/common/gptp_cfg.hpp
+++ b/common/gptp_cfg.hpp
@@ -76,6 +76,7 @@ class GptpIniParser
             unsigned int seqIdAsCapableThresh;
             uint16_t lostPdelayRespThresh;
             PortState port_state;
+            bool allowNegativeCorrField;
 
             /*ethernet adapter data set*/
 	    std::string ifname;
@@ -150,6 +151,15 @@ class GptpIniParser
         unsigned int getSyncReceiptThresh(void)
         {
             return _config.syncReceiptThresh;
+        }
+
+        /**
+         * @brief  Reads the allowNegativeCorrectionField flag from the configuration file
+         * @return allowNegativeCorrectionField from the .ini file
+         */
+        bool getAllowNegativeCorrField(void)
+        {
+            return _config.allowNegativeCorrField;
         }
 
 	/**

--- a/common/ptp_message.cpp
+++ b/common/ptp_message.cpp
@@ -1053,12 +1053,12 @@ void PTPMessageFollowUp::processMessage
 	{
 		if( port->getAllowNegativeCorrField() )
 		{
-			GPTP_LOG_WARNING
+			GPTP_LOG_INFO
 					( "Received Follow Up with negative correctionField: %Ld", correctionField );
 		}
 		else
 		{
-			GPTP_LOG_EXCEPTION
+			GPTP_LOG_ERROR
 					( "Discard received Follow Up with negative correctionField: %Ld", correctionField );
 			goto done;
 		}

--- a/common/ptp_message.cpp
+++ b/common/ptp_message.cpp
@@ -1049,6 +1049,20 @@ void PTPMessageFollowUp::processMessage
 	master_local_freq_offset /= port->getPeerRateOffset();
 
 	correctionField /= 1 << 16;
+	if( correctionField < 0 )
+	{
+		if( port->getAllowNegativeCorrField() )
+		{
+			GPTP_LOG_WARNING
+					( "Received Follow Up with negative correctionField: %Ld", correctionField );
+		}
+		else
+		{
+			GPTP_LOG_EXCEPTION
+					( "Discard received Follow Up with negative correctionField: %Ld", correctionField );
+			goto done;
+		}
+	}
 	correction = (int64_t)
 		((delay * master_local_freq_offset) + correctionField);
 

--- a/gptp_cfg.ini
+++ b/gptp_cfg.ini
@@ -30,7 +30,7 @@ neighborPropDelayThresh = 800
 syncReceiptThresh = 8
 
 # Permission flag for processing SyncFollowUp messages with
-# negative correction field, 0 = forbiden, 1 = permitted.
+# negative correction field, 0 = forbidden, 1 = permitted.
 allowNegativeCorrectionField = 0
 
 [eth]

--- a/gptp_cfg.ini
+++ b/gptp_cfg.ini
@@ -29,6 +29,10 @@ neighborPropDelayThresh = 800
 # up to 1 second of wrong messages before switching
 syncReceiptThresh = 8
 
+# Permission flag for processing SyncFollowUp messages with
+# negative correction field, 0 = forbiden, 1 = permitted.
+allowNegativeCorrectionField = 0
+
 [eth]
 
 # Older deprecated format

--- a/linux/src/daemon_cl.cpp
+++ b/linux/src/daemon_cl.cpp
@@ -73,7 +73,7 @@ void print_usage( char *arg0 ) {
 			"%s <network interface> [-S] [-P] [-M <filename>] "
 			"[-G <group>] [-R <priority 1>] "
 			"[-D <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>] "
-			"[-T] [-L] [-E] [-GM] [-INITSYNC <value>] [-OPERSYNC <value>] "
+			"[-T] [-L] [-E] [-GM] [-N] [-INITSYNC <value>] [-OPERSYNC <value>] "
 			"[-INITPDELAY <value>] [-OPERPDELAY <value>] "
 			"[-F <path to gptp_cfg.ini file>] "
 			"\n",
@@ -90,6 +90,7 @@ void print_usage( char *arg0 ) {
 		  "\t-L force slave (ignored when Automotive Profile set)\n"
 		  "\t-E enable test mode (as defined in AVnu automotive profile)\n"
 		  "\t-V enable AVnu Automotive Profile\n"
+		  "\t-N allow processing SyncFollowUp with negative correction field\n"
 		  "\t-GM set grandmaster for Automotive Profile\n"
 		  "\t-INITSYNC <value> initial sync interval (Log base 2. 0 = 1 second)\n"
 		  "\t-OPERSYNC <value> operational sync interval (Log base 2. 0 = 1 second)\n"
@@ -183,6 +184,7 @@ int main(int argc, char **argv)
 	portInit.isGM = false;
 	portInit.testMode = false;
 	portInit.linkUp = false;
+	portInit.allowNegativeCorrField = false;
 	portInit.initialLogSyncInterval = LOG2_INTERVAL_INVALID;
 	portInit.initialLogPdelayReqInterval = LOG2_INTERVAL_INVALID;
 	portInit.operLogPdelayReqInterval = LOG2_INTERVAL_INVALID;
@@ -310,6 +312,9 @@ int main(int argc, char **argv)
 			else if (strcmp(argv[i] + 1, "E") == 0) {
 				portInit.testMode = true;
 			}
+			else if (strcmp(argv[i] + 1, "N") == 0) {
+				portInit.allowNegativeCorrField = true;
+			}
 			else if (strcmp(argv[i] + 1, "INITSYNC") == 0) {
 				portInit.initialLogSyncInterval = atoi(argv[++i]);
 			}
@@ -429,6 +434,10 @@ int main(int argc, char **argv)
 			{
 				ether_phy_delay = iniParser.getPhyDelay();
 			}
+
+			portInit.allowNegativeCorrField = iniParser.getAllowNegativeCorrField();
+			GPTP_LOG_INFO("SyncFollowUp with negative correction field: %s",
+						  portInit.allowNegativeCorrField ? "permitted" : "forbiden");
 		}
 
 	}

--- a/linux/src/daemon_cl.cpp
+++ b/linux/src/daemon_cl.cpp
@@ -437,7 +437,7 @@ int main(int argc, char **argv)
 
 			portInit.allowNegativeCorrField = iniParser.getAllowNegativeCorrField();
 			GPTP_LOG_INFO("SyncFollowUp with negative correction field: %s",
-						  portInit.allowNegativeCorrField ? "permitted" : "forbiden");
+						  portInit.allowNegativeCorrField ? "permitted" : "forbidden");
 		}
 
 	}


### PR DESCRIPTION
Simple robustness against switch/bridge issue of putting negative values in CorrectionField.