### PR TITLE
fprintf and 'isGM' fixes 

### DIFF
--- a/common/ether_port.hpp
+++ b/common/ether_port.hpp
@@ -100,7 +100,7 @@ class EtherPort : public CommonPort
 
 	/* Automotive Profile : Static variables */
 	// port_state : already defined as port_state
-	bool isGM;
+	// isGM : already defined as isGM;
 	// asCapable : already defined as asCapable
 	signed char operLogPdelayReqInterval;
 	signed char operLogSyncInterval;

--- a/linux/src/linux_hal_common.cpp
+++ b/linux/src/linux_hal_common.cpp
@@ -585,8 +585,8 @@ unsigned long LinuxTimer::sleep(unsigned long micros) {
 		ret = nanosleep( &req, &rem );
 	}
 	if( ret == -1 ) {
-		fprintf
-			( stderr, "Error calling nanosleep: %s\n", strerror( errno ));
+		GPTP_LOG_ERROR
+			("Error calling nanosleep: %s", strerror( errno ));
 		_exit(-1);
 	}
 	return micros;
@@ -723,7 +723,7 @@ OSLockResult LinuxLock::lock() {
 	int lock_c;
 	lock_c = pthread_mutex_lock(&_private->mutex);
 	if(lock_c != 0) {
-		fprintf( stderr, "LinuxLock: lock failed %d\n", lock_c );
+		GPTP_LOG_ERROR("LinuxLock: lock failed %d", lock_c);
 		return oslock_fail;
 	}
 	return oslock_ok;
@@ -740,7 +740,7 @@ OSLockResult LinuxLock::unlock() {
 	int lock_c;
 	lock_c = pthread_mutex_unlock(&_private->mutex);
 	if(lock_c != 0) {
-		fprintf( stderr, "LinuxLock: unlock failed %d\n", lock_c );
+		GPTP_LOG_ERROR("LinuxLock: unlock failed %d", lock_c);
 		return oslock_fail;
 	}
 	return oslock_ok;


### PR DESCRIPTION
Removal of uninitialized 'isGM' variable from EtherPort class

It is defined/initialized in CommonPort class. During extensive
testing it was sporadically observed that syncs messages were sent
by slave.

See discussion: AVnu/OpenAvnu#737