### PR TITLE
gptp: added threads synchronization during daemon shutdown

### DIFF
--- a/common/common_port.hpp
+++ b/common/common_port.hpp
@@ -339,6 +339,8 @@ private:
 
 	OSThread *listening_thread;
 	OSThread *link_thread;
+	bool listening_thread_running;
+	bool link_thread_running;
 
 	FrequencyRatio _peer_rate_offset;
 	Timestamp _peer_offset_ts_theirs;
@@ -1042,14 +1044,100 @@ public:
 		return net_iface->getPayloadOffset();
 	}
 
+	/**
+	 * @brief Starts link thread
+	 * @return TRUE if ok, FALSE if error
+	 */
 	bool linkWatch( OSThreadFunction func, OSThreadFunctionArg arg )
 	{
 		return link_thread->start( func, arg );
 	}
 
+	/**
+	 * @brief Starts listening thread
+	 * @return TRUE if ok, FALSE if error
+	 */
 	bool linkOpen( OSThreadFunction func, OSThreadFunctionArg arg )
 	{
 		return listening_thread->start( func, arg );
+	}
+
+	/**
+	 * @brief Terminates the thread
+	 * @return void
+	 */
+	void stopLinkWatchThread()
+	{
+		GPTP_LOG_VERBOSE("Stop link watch thread");
+		setLinkThreadRunning(false);
+	}
+
+	/**
+	 * @brief Terminates the thread
+	 * @return void
+	 */
+	void stopListeningThread()
+	{
+		GPTP_LOG_VERBOSE("Stop listening thread");
+		setListeningThreadRunning(false);
+	}
+
+	/**
+	 * @brief Joins terminated thread
+	 * @param exit_code [out]
+	 * @return TRUE if ok, FALSE if error
+	 */
+	bool joinLinkWatchThread( OSThreadExitCode & exit_code )
+	{
+		return link_thread->join( exit_code );
+	}
+
+	/**
+	 * @brief Joins terminated thread
+	 * @param exit_code [out]
+	 * @return TRUE if ok, FALSE if error
+	 */
+	bool joinListeningThread( OSThreadExitCode & exit_code )
+	{
+		return listening_thread->join( exit_code );
+	}
+
+	/**
+	 * @brief Sets the listeningThreadRunning flag
+	 * @param state value to be set
+	 * @return void
+	 */
+	void setListeningThreadRunning(bool state)
+	{
+		listening_thread_running = state;
+	}
+
+	/**
+	 * @brief Gets the listeningThreadRunning flag
+	 * @return TRUE if running, FALSE if stopped
+	 */
+	bool getListeningThreadRunning()
+	{
+		return listening_thread_running;
+	}
+
+	/**
+	 * @brief Sets the linkThreadRunning flag
+	 * @param state value to be set
+	 * @return void
+	 */
+	void setLinkThreadRunning(bool state)
+	{
+		link_thread_running = state;
+	}
+
+	/**
+	 * @brief Gets the linkThreadRunning flag
+	 * @return TRUE if running, FALSE if stopped
+	 */
+	bool getLinkThreadRunning()
+	{
+		return link_thread_running;
 	}
 
 	/**

--- a/common/ether_port.cpp
+++ b/common/ether_port.cpp
@@ -245,7 +245,9 @@ void *EtherPort::openPort( EtherPort *port )
 {
 	port_ready_condition->signal();
 
-	while (1) {
+	setListeningThreadRunning(true);
+
+	while ( getListeningThreadRunning() ) {
 		uint8_t buf[128];
 		LinkLayerAddress remote;
 		net_result rrecv;
@@ -263,7 +265,7 @@ void *EtherPort::openPort( EtherPort *port )
 			break;
 		}
 	}
-
+	GPTP_LOG_DEBUG("Listening thread terminated ...");
 	return NULL;
 }
 

--- a/linux/src/daemon_cl.cpp
+++ b/linux/src/daemon_cl.cpp
@@ -530,6 +530,13 @@ int main(int argc, char **argv)
 		}
 	}
 
+	OSThreadExitCode listenExitCode, linkExitCode;
+	pPort->stopListeningThread();
+	pPort->stopLinkWatchThread();
+	pPort->joinListeningThread(listenExitCode);
+	pPort->joinLinkWatchThread(linkExitCode);
+	GPTP_LOG_INFO("All threads terminated");
+
 	if( ipc ) delete ipc;
 
 	GPTP_LOG_UNREGISTER();

--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -546,7 +546,7 @@ class LinuxThread : public OSThread {
 	virtual bool start(OSThreadFunction function, void *arg);
 
 	/**
-	 * @brief  Joins a new thread
+	 * @brief  Joins terminated thread
 	 * @param  exit_code Callback's return code
 	 * @return TRUE if ok, FALSE if error.
 	 */


### PR DESCRIPTION
For link and listening threads (Linux only). Those threads
are cancelled and joined before main thread terminates.