### PR TITLE
Initialize 'ret' value

### DIFF
--- a/common/ether_port.cpp
+++ b/common/ether_port.cpp
@@ -323,7 +323,7 @@ void EtherPort::sendGeneralPort
 
 bool EtherPort::_processEvent( Event e )
 {
-	bool ret;
+	bool ret = false;
 
 	switch (e) {
 	case POWERUP:


### PR DESCRIPTION
Initialize value to prevent run-time check failures: "The variable 'ret' is being used without being initialized"