### PR TITLE
linux_hal_common: the resources (sd_*) not freed (SCA _002/_003/_017 #38/#39/#51)

### DIFF
--- a/linux/src/linux_hal_common.cpp
+++ b/linux/src/linux_hal_common.cpp
@@ -79,8 +79,8 @@ Timestamp tsToTimestamp(struct timespec *ts)
 }
 
 LinuxNetworkInterface::~LinuxNetworkInterface() {
-	close( sd_event );
-	close( sd_general );
+	if ( sd_event != -1 ) close( sd_event );
+	if ( sd_general != -1 ) close( sd_general );
 }
 
 net_result LinuxNetworkInterface::send
@@ -1035,27 +1035,27 @@ bool LinuxNetworkInterfaceFactory::createInterface
 
 	LinuxNetworkInterface *net_iface_l = new LinuxNetworkInterface();
 
-	if( !net_iface_l->net_lock.init()) {
-		GPTP_LOG_ERROR( "Failed to initialize network lock");
-		return false;
-	}
-
 	InterfaceName *ifname = dynamic_cast<InterfaceName *>(label);
 	if( ifname == NULL ){
 		GPTP_LOG_ERROR( "ifname == NULL");
-		return false;
+		goto exit_error;
+	}
+
+	if( !net_iface_l->net_lock.init()) {
+		GPTP_LOG_ERROR( "Failed to initialize network lock");
+		goto exit_error;
 	}
 
 	net_iface_l->sd_general = socket( PF_PACKET, SOCK_DGRAM, 0 );
 	if( net_iface_l->sd_general == -1 ) {
 		GPTP_LOG_ERROR( "failed to open general socket: %s", strerror(errno));
-		return false;
+		goto exit_error;
 	}
 	net_iface_l->sd_event = socket( PF_PACKET, SOCK_DGRAM, 0 );
 	if( net_iface_l->sd_event == -1 ) {
 		GPTP_LOG_ERROR
 			( "failed to open event socket: %s ", strerror(errno));
-		return false;
+		goto exit_error;
 	}
 
 	memset( &device, 0, sizeof(device));
@@ -1064,7 +1064,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	if( err == -1 ) {
 		GPTP_LOG_ERROR
 			( "Failed to get interface address: %s", strerror( errno ));
-		return false;
+		goto exit_error;
 	}
 
 	addr = LinkLayerAddress( (uint8_t *)&device.ifr_hwaddr.sa_data );
@@ -1073,7 +1073,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	if( err == -1 ) {
 		GPTP_LOG_ERROR
 			( "Failed to get interface index: %s", strerror( errno ));
-		return false;
+		goto exit_error;
 	}
 	ifindex = device.ifr_ifindex;
 	net_iface_l->ifindex = ifindex;
@@ -1089,7 +1089,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 		GPTP_LOG_ERROR
 			( "Unable to add PTP multicast addresses to port id: %u",
 			  ifindex );
-		return false;
+		goto exit_error;
 	}
 
 	memset( &ifsock_addr, 0, sizeof( ifsock_addr ));
@@ -1101,21 +1101,24 @@ bool LinuxNetworkInterfaceFactory::createInterface
 		  sizeof( ifsock_addr ));
 	if( err == -1 ) {
 		GPTP_LOG_ERROR( "Call to bind() failed: %s", strerror(errno) );
-		return false;
+		goto exit_error;
 	}
 
 	net_iface_l->timestamper =
 		dynamic_cast <LinuxTimestamper *>(timestamper);
 	if(net_iface_l->timestamper == NULL) {
 		GPTP_LOG_ERROR( "timestamper == NULL" );
-		return false;
+		goto exit_error;
 	}
 	if( !net_iface_l->timestamper->post_init
 		( ifindex, net_iface_l->sd_event, &net_iface_l->net_lock )) {
 		GPTP_LOG_ERROR( "post_init failed\n" );
-		return false;
+		goto exit_error;
 	}
 	*net_iface = net_iface_l;
-
 	return true;
+
+exit_error:
+	delete net_iface_l;
+	return false;
 }

--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -231,7 +231,10 @@ protected:
 	/**
 	 * @brief Default constructor
 	 */
-	LinuxNetworkInterface() {};
+	LinuxNetworkInterface() {
+		sd_event = -1;
+		sd_general = -1;
+	}
 };
 
 /**


### PR DESCRIPTION
Static code analysis fixes _002 _003 _017 (Issues #38 #39 #51)

Added sd_general and sd_event initalization in LinuxNetworkInterface() constructor; now sockets can be properly closed in relevant destructor code, which was not called at all in case of failures.
ifname initialization moved up (net_lock.init() down) to solve compilation error ("jump to label 'exit_error' crosses initialization of 'InterfaceName* ifname")