### PR TITLE
avbts_message: coercion alters values (organizationId) (SCA _039/_040…

### DIFF
--- a/common/avbts_message.hpp
+++ b/common/avbts_message.hpp
@@ -745,9 +745,9 @@ class FollowUpTLV {
 	FollowUpTLV() {
 		tlvType = PLAT_htons(0x3);
 		lengthField = PLAT_htons(28);
-		organizationId[0] = '\x00';
-		organizationId[1] = '\x80';
-		organizationId[2] = '\xC2';
+		organizationId[0] = 0x00;
+		organizationId[1] = 0x80;
+		organizationId[2] = 0xC2;
 		organizationSubType_ms = 0;
 		organizationSubType_ls = PLAT_htons(1);
 		cumulativeScaledRateOffset = PLAT_htonl(0);
@@ -1138,9 +1138,9 @@ class SignallingTLV {
 	SignallingTLV() {
 		tlvType = PLAT_htons(0x3);
 		lengthField = PLAT_htons(12);
-		organizationId[0] = '\x00';
-		organizationId[1] = '\x80';
-		organizationId[2] = '\xC2';
+		organizationId[0] = 0x00;
+		organizationId[1] = 0x80;
+		organizationId[2] = 0xC2;
 		organizationSubType_ms = 0;
 		organizationSubType_ls = PLAT_htons(2);
 		linkDelayInterval = 0;


### PR DESCRIPTION
…/_041/_042 #59)

Static code analysis fix _039/_040/_041/_042 (Issue #59)

'\x80' and '\xC2' are interpreted as (signed) char, while organizationId
is defined as unsigned char (uint8_t). The values in the packets seem
to be correct, so the fix is more or less to get rid of SCA complaints.