### PR TITLE
avbts_message: coercion alters values (Signalling intervals type) (SC…

### DIFF
--- a/common/avbts_message.hpp
+++ b/common/avbts_message.hpp
@@ -1126,9 +1126,9 @@ class SignallingTLV {
 	uint8_t organizationId[3];
 	uint8_t organizationSubType_ms;
 	uint16_t organizationSubType_ls;
-	uint8_t linkDelayInterval;
-	uint8_t timeSyncInterval;
-	uint8_t announceInterval;
+	int8_t linkDelayInterval;
+	int8_t timeSyncInterval;
+	int8_t announceInterval;
 	uint8_t flags;
 	uint16_t reserved;
  public:


### PR DESCRIPTION
…A _044/_045 #61)

Static code analysis fix _044/_045 (Issue #61)

linkDelayInterval, timeSyncInterval and announceInterval should be
declared as int8_t (Integer8 according to 802.1AS-2011).