### PR TITLE
inih: isspace() - negative character value (SCA _018/_019/_020 #52/#53/#54)

### DIFF
--- a/common/ini.c
+++ b/common/ini.c
@@ -24,7 +24,7 @@ http://code.google.com/p/inih/
 static char* rstrip(char* s)
 {
     char* p = s + strlen(s);
-    while (p > s && isspace(*--p))
+    while (p > s && isspace((unsigned char)(*--p)))
         *p = '\0';
     return s;
 }
@@ -32,7 +32,7 @@ static char* rstrip(char* s)
 /* Return pointer to first non-whitespace char in given string. */
 static char* lskip(const char* s)
 {
-    while (*s && isspace(*s))
+    while (*s && isspace((unsigned char)(*s)))
         s++;
     return (char*)s;
 }
@@ -44,7 +44,7 @@ static char* find_char_or_comment(const char* s, char c)
 {
     int was_whitespace = 0;
     while (*s && *s != c && !(was_whitespace && *s == ';')) {
-        was_whitespace = isspace(*s);
+        was_whitespace = isspace((unsigned char)(*s));
         s++;
     }
     return (char*)s;


### PR DESCRIPTION
Static code analysis fixes _018 _019 _020 (Issues #52/#53/#54)

isspace() is invoked here with an argument of signed type char, but
only has defined behavior for int arguments that are either representable
as unsigned char or equal to the value of macro EOF(-1).

See also "Fix issue 25: Be sure to call isspace() with unsigned char" in inih project from 2013:
https://github.com/benhoyt/inih/commit/9b0825f08d1fe88af4c73eb5b9ce87774256fe7f