### PR TITLE
avbts_osnet: InterfaceName - No Space For Null Terminator (SCA _029 #64)

### DIFF
--- a/common/avbts_osnet.hpp
+++ b/common/avbts_osnet.hpp
@@ -172,6 +172,7 @@ class InterfaceName: public InterfaceLabel {
 	InterfaceName(char *name, int length) {
 		this->name = new char[length + 1];
 		PLAT_strncpy(this->name, name, length);
+		this->name[length] = '\0';
 	}
 	~InterfaceName() {
 		delete(this->name);


### PR DESCRIPTION
Static code analysis fix _029 (Issue #64)

Explicitly set null terminator in InterfaceName constructor.