### PR TITLE
ptp_message: eport null pointer dereference (SCA _038 #69)

### DIFF
--- a/common/ptp_message.cpp
+++ b/common/ptp_message.cpp
@@ -1582,9 +1582,9 @@ void PTPMessagePathDelayRespFollowUp::processMessage
 	EtherPort *eport = dynamic_cast <EtherPort *> (port);
 	if (eport == NULL)
 	{
-		GPTP_LOG_ERROR( "Received Pdelay Response FollowUp on wrong "
-				"port type" );
-		goto abort;
+		GPTP_LOG_ERROR( "Received Pdelay Response FollowUp on wrong port type" );
+		_gc = true;
+		return;
 	}
 
 	if (port->getPortState() == PTP_DISABLED) {


### PR DESCRIPTION
Static code analysis fix _038 (Issue #69)

There is some inconsistency when looking at other _processMessage()_ functions, so I think it's best to make it similar to  _PTPMessagePathDelayResp::processMessage()_