### PR TITLE
linux_hal_persist_file: writeCB null pointer dereference (SCA _036 #63)

### DIFF
--- a/linux/src/linux_hal_persist_file.cpp
+++ b/linux/src/linux_hal_persist_file.cpp
@@ -54,6 +54,7 @@ public:
 		restoredata = ((void *)-1);
 		storedDataLength = 0;
 		memoryDataLength = 0;
+		writeCB = nullptr;
 	}
 
 	~LinuxGPTPPersistFile() {} ;
@@ -117,10 +118,6 @@ public:
 
 	bool triggerWriteStorage(void)
 	{
-		if (!writeCB) {
-			GPTP_LOG_ERROR("Persistent write callback not registered");
-		}
-
 		bool result = false;
 		if (memoryDataLength > storedDataLength) {
 			int ret = ftruncate(persistFD, memoryDataLength);
@@ -142,7 +139,13 @@ public:
 			}
 		}
 
-		writeCB((char *)restoredata, storedDataLength);
+		if (!writeCB) {
+			GPTP_LOG_ERROR("Persistent write callback not registered");
+		}
+		else {
+			writeCB((char *)restoredata, storedDataLength);
+		}
+
 		return result;
 	}
 };


### PR DESCRIPTION
Static code analysis fix _036 (Issue #63)

writeCB called in case it was registered only.