### PR TITLE
linux_hal_common: the resource (LinuxCondition *) was not freed (SCA …

### DIFF
--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -383,7 +383,11 @@ public:
 	OSCondition *createCondition() const
 	{
 		LinuxCondition *result = new LinuxCondition();
-		return result->initialize() ? result : NULL;
+		if (!result->initialize()) {
+			delete result;
+			result = NULL;
+		}
+		return result;
 	}
 };
 


### PR DESCRIPTION
…_013 / #47)

Static code analysis fix _013 (Issue #47)

In case of failing initialize() the resource pointed by _result_ was not freed.