### PR TITLE
offsetScaledLogVariance: change it to unsigned short (SCA _032 #65)

### DIFF
--- a/common/avbts_clock.hpp
+++ b/common/avbts_clock.hpp
@@ -78,7 +78,7 @@ struct ClockQuality {
 	unsigned char clockAccuracy; 		/*!< Clock Accuracy - clause 8.6.2.3.
 										  Indicates the expected time accuracy of
 										  a clock master.*/
-	int16_t offsetScaledLogVariance;	/*!< ::Offset Scaled log variance - Clause 8.6.2.4.
+	uint16_t offsetScaledLogVariance;	/*!< ::Offset Scaled log variance - Clause 8.6.2.4.
 										  Is the scaled, offset representation
 										  of an estimate of the PTP variance. The
 										  PTP variance characterizes the

--- a/common/avbts_osipc.hpp
+++ b/common/avbts_osipc.hpp
@@ -119,7 +119,7 @@ public:
 		uint8_t  clock_identity[],
 		uint8_t  priority1,
 		uint8_t  clock_class,
-		int16_t  offset_scaled_log_variance,
+		uint16_t  offset_scaled_log_variance,
 		uint8_t  clock_accuracy,
 		uint8_t  priority2,
 		uint8_t  domain_number,

--- a/common/ipcdef.hpp
+++ b/common/ipcdef.hpp
@@ -82,7 +82,7 @@ typedef struct {
 	uint8_t  clock_identity[PTP_CLOCK_IDENTITY_LENGTH];	//!< The clock identity of the interface
 	uint8_t  priority1;				//!< The priority1 field of the grandmaster functionality of the interface, or 0xFF if not supported
 	uint8_t  clock_class;			//!< The clockClass field of the grandmaster functionality of the interface, or 0xFF if not supported
-	int16_t  offset_scaled_log_variance;	//!< The offsetScaledLogVariance field of the grandmaster functionality of the interface, or 0x0000 if not supported
+	uint16_t offset_scaled_log_variance;	//!< The offsetScaledLogVariance field of the grandmaster functionality of the interface, or 0x0000 if not supported
 	uint8_t  clock_accuracy;		//!< The clockAccuracy field of the grandmaster functionality of the interface, or 0xFF if not supported
 	uint8_t  priority2;				//!< The priority2 field of the grandmaster functionality of the interface, or 0xFF if not supported
 	uint8_t  domain_number;			//!< The domainNumber field of the grandmaster functionality of the interface, or 0 if not supported

--- a/linux/shm_test/shm_test.cpp
+++ b/linux/shm_test/shm_test.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
             (unsigned int) ptpData->clock_identity[6], (unsigned int) ptpData->clock_identity[7]);
     fprintf(stdout, "priority1 %u\n", (unsigned int) ptpData->priority1);
     fprintf(stdout, "clock_class %u\n", (unsigned int) ptpData->clock_class);
-    fprintf(stdout, "offset_scaled_log_variance %d\n", (unsigned int) ptpData->offset_scaled_log_variance);
+    fprintf(stdout, "offset_scaled_log_variance %u\n", (unsigned int) ptpData->offset_scaled_log_variance);
     fprintf(stdout, "clock_accuracy %u\n", (unsigned int) ptpData->clock_accuracy);
     fprintf(stdout, "priority2 %u\n", (unsigned int) ptpData->priority2);
     fprintf(stdout, "domain_number %u\n", (unsigned int) ptpData->domain_number);

--- a/linux/shm_test/shm_test.cpp
+++ b/linux/shm_test/shm_test.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
             (unsigned int) ptpData->clock_identity[6], (unsigned int) ptpData->clock_identity[7]);
     fprintf(stdout, "priority1 %u\n", (unsigned int) ptpData->priority1);
     fprintf(stdout, "clock_class %u\n", (unsigned int) ptpData->clock_class);
-    fprintf(stdout, "offset_scaled_log_variance %d\n", (int) ptpData->offset_scaled_log_variance);
+    fprintf(stdout, "offset_scaled_log_variance %d\n", (unsigned int) ptpData->offset_scaled_log_variance);
     fprintf(stdout, "clock_accuracy %u\n", (unsigned int) ptpData->clock_accuracy);
     fprintf(stdout, "priority2 %u\n", (unsigned int) ptpData->priority2);
     fprintf(stdout, "domain_number %u\n", (unsigned int) ptpData->domain_number);

--- a/linux/src/linux_hal_common.cpp
+++ b/linux/src/linux_hal_common.cpp
@@ -992,7 +992,7 @@ bool LinuxSharedMemoryIPC::update_network_interface(
 	uint8_t  clock_identity[],
 	uint8_t  priority1,
 	uint8_t  clock_class,
-	int16_t  offset_scaled_log_variance,
+	uint16_t  offset_scaled_log_variance,
 	uint8_t  clock_accuracy,
 	uint8_t  priority2,
 	uint8_t  domain_number,

--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -706,7 +706,7 @@ public:
 		uint8_t  clock_identity[],
 		uint8_t  priority1,
 		uint8_t  clock_class,
-		int16_t  offset_scaled_log_variance,
+		uint16_t offset_scaled_log_variance,
 		uint8_t  clock_accuracy,
 		uint8_t  priority2,
 		uint8_t  domain_number,


### PR DESCRIPTION
Static code analysis fix _032 (Issue #65)

SCA complains here about ntohs() but the real issue is the type of offsetScaledLogVariance,
which currently in the code is int16_t. There seems to be inconsistency in IEEE 802.1AS-2011:

    - in 6.3.3.8 ClockQuality offsetScaledLogVariance is defined as UInteger16;
    - later in the document it's used as Integer16 (Table 14-1, code examples etc.);

This inconsistency has been corrected in IEEE 802.1AS-2011/Cor 1-2013 where UInteger16 was specified
in the Table 14-1 and used later in the code examples. IEEE 1588-2008 defines offsetScaledLogVariance also
as UInteger16 (see 5.3.7 ClockQuality).