### PR TITLE
common_port: modify the types of counters and initialize them

### DIFF
--- a/common/common_port.cpp
+++ b/common/common_port.cpp
@@ -72,6 +72,7 @@ CommonPort::CommonPort( PortInit_t *portInit ) :
 	asCapable = false;
 	link_speed = INVALID_LINKSPEED;
 	allow_negative_correction_field = portInit->allowNegativeCorrField;
+	memset(&counters, 0, sizeof(counters));
 }
 
 CommonPort::~CommonPort()

--- a/common/common_port.hpp
+++ b/common/common_port.hpp
@@ -279,22 +279,22 @@ typedef struct {
  * @brief Structure for Port Counters
  */
 typedef struct {
-	int32_t ieee8021AsPortStatRxSyncCount;
-	int32_t ieee8021AsPortStatRxFollowUpCount;
-	int32_t ieee8021AsPortStatRxPdelayRequest;
-	int32_t ieee8021AsPortStatRxPdelayResponse;
-	int32_t ieee8021AsPortStatRxPdelayResponseFollowUp;
-	int32_t ieee8021AsPortStatRxAnnounce;
-	int32_t ieee8021AsPortStatRxPTPPacketDiscard;
-	int32_t ieee8021AsPortStatRxSyncReceiptTimeouts;
-	int32_t ieee8021AsPortStatAnnounceReceiptTimeouts;
-	int32_t ieee8021AsPortStatPdelayAllowedLostResponsesExceeded;
-	int32_t ieee8021AsPortStatTxSyncCount;
-	int32_t ieee8021AsPortStatTxFollowUpCount;
-	int32_t ieee8021AsPortStatTxPdelayRequest;
-	int32_t ieee8021AsPortStatTxPdelayResponse;
-	int32_t ieee8021AsPortStatTxPdelayResponseFollowUp;
-	int32_t ieee8021AsPortStatTxAnnounce;
+	uint32_t ieee8021AsPortStatRxSyncCount;
+	uint32_t ieee8021AsPortStatRxFollowUpCount;
+	uint32_t ieee8021AsPortStatRxPdelayRequest;
+	uint32_t ieee8021AsPortStatRxPdelayResponse;
+	uint32_t ieee8021AsPortStatRxPdelayResponseFollowUp;
+	uint32_t ieee8021AsPortStatRxAnnounce;
+	uint32_t ieee8021AsPortStatRxPTPPacketDiscard;
+	uint32_t ieee8021AsPortStatRxSyncReceiptTimeouts;
+	uint32_t ieee8021AsPortStatAnnounceReceiptTimeouts;
+	uint32_t ieee8021AsPortStatPdelayAllowedLostResponsesExceeded;
+	uint32_t ieee8021AsPortStatTxSyncCount;
+	uint32_t ieee8021AsPortStatTxFollowUpCount;
+	uint32_t ieee8021AsPortStatTxPdelayRequest;
+	uint32_t ieee8021AsPortStatTxPdelayResponse;
+	uint32_t ieee8021AsPortStatTxPdelayResponseFollowUp;
+	uint32_t ieee8021AsPortStatTxAnnounce;
 } PortCounters_t;
 
 /**


### PR DESCRIPTION
According to the MIB files of IEEE802.1, the types of all those counters should be Counter32 which means a non-negative integer.

Reference: https://www.ieee802.org/1/files/public/MIBs/IEEE8021-AS-V2-MIB-202006080000Z.mib